### PR TITLE
Build fixes

### DIFF
--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -21,8 +21,8 @@ export FILENAME="obs-websocket-$VERSION.pkg"
 export LATEST_FILENAME="obs-websocket-latest-$LATEST_VERSION.pkg"
 
 echo "-- Copying Qt dependencies"
-cp $WS_LIB ./build
-cp $NET_LIB ./build
+if [ ! -f ./build/$(basename $WS_LIB) ]; then cp $WS_LIB ./build; fi
+if [ ! -f ./build/$(basename $NET_LIB) ]; then cp $NET_LIB ./build; fi
 
 chmod +rw ./build/QtWebSockets ./build/QtNetwork
 

--- a/CI/package-macos.sh
+++ b/CI/package-macos.sh
@@ -28,12 +28,14 @@ chmod +rw ./build/QtWebSockets ./build/QtNetwork
 
 echo "-- Modifying QtNetwork"
 install_name_tool \
+	-id @rpath/QtNetwork \
 	-change /usr/local/opt/qt/lib/QtNetwork.framework/Versions/5/QtNetwork @rpath/QtNetwork \
 	-change $QT_CELLAR_PREFIX/lib/QtCore.framework/Versions/5/QtCore @rpath/QtCore \
 	./build/QtNetwork
 
 echo "-- Modifying QtWebSockets"
 install_name_tool \
+	-id @rpath/QtWebSockets \
 	-change /usr/local/opt/qt/lib/QtWebSockets.framework/Versions/5/QtWebSockets @rpath/QtWebSockets \
 	-change $QT_CELLAR_PREFIX/lib/QtNetwork.framework/Versions/5/QtNetwork @rpath/QtNetwork \
 	-change $QT_CELLAR_PREFIX/lib/QtCore.framework/Versions/5/QtCore @rpath/QtCore \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ endif()
 if(APPLE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fvisibility=default")
 
+	set(CMAKE_SKIP_RPATH TRUE)
 	set_target_properties(obs-websocket PROPERTIES PREFIX "")
 	target_link_libraries(obs-websocket "${OBS_FRONTEND_LIB}")
 endif()


### PR DESCRIPTION
These few changes make it so that all library references (in `QtNetwork`, `QtWebSockets`) use `@rpath` as their path (e7b7af8), and no `LC_RPATH` commands with the build environment's libobs location remain in `obs-websocket.so` (0f78034).
Most problems probably arise for users that build `obs-websocket.so` themselves, since the remaining references could lead to dyld trying to load two versions of Qt: the one shipped with OBS in `@rpath` and any other version on the system (e.g. the one used to build the obs-studio inside the obs-websocket build). Nevertheless I figured it would be good practice to have all paths sane even in the shipped version.

There's also a minor convenience for self-builders in that the `package-macos.sh` script doesn't error out when the `Qt*` libraries are already in the build directory. Running `install_name_tool` multiple times on the Qt libs is a no-op, since all the changes will have been applied already.